### PR TITLE
Update quarto_publish.yml

### DIFF
--- a/.github/workflows/quarto_publish.yml
+++ b/.github/workflows/quarto_publish.yml
@@ -50,4 +50,4 @@ jobs:
           run: |
             git config user.name "${{ github.actor }}"
             git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
-            quarto publish gh-pages . --no-browser
+            quarto publish gh-pages index.qmd --no-browser


### PR DESCRIPTION
Kiya noted that publishing doesn't run properly. See also:
https://stackoverflow.com/questions/78727508/quarto-and-github-actions-error-the-specified-path-is-not-a-website